### PR TITLE
fix(移动端): Dock 模式键盘栏遮挡、工具栏事件丢失、侧滑返回优化

### DIFF
--- a/index.js
+++ b/index.js
@@ -14589,6 +14589,10 @@ ipcRenderer.on('lumina-close', () => {
             };
         }
 
+        this._bindInputToolbar(input);
+    }
+
+    _bindInputToolbar(input) {
         // 标签按钮
         const tagBtn = this.container.querySelector('#toolbar-tag');
         if (tagBtn) {
@@ -14628,7 +14632,7 @@ ipcRenderer.on('lumina-close', () => {
         const olBtn = this.container.querySelector('#toolbar-ol');
         if (olBtn) {
             olBtn.addEventListener('click', () => {
-                // 获取当前行号或默?
+                // 获取当前行号或默认值
                 const lines = input.value.substring(0, input.selectionStart).split('\n');
                 const currentLine = lines[lines.length - 1];
                 const match = currentLine.match(/^(\d+)\.\s/);
@@ -14646,7 +14650,6 @@ ipcRenderer.on('lumina-close', () => {
                 this.showMentionPicker(input);
             });
         }
-
     }
 
     // 在光标位置插入文?
@@ -22146,6 +22149,9 @@ ipcRenderer.on('lumina-close', () => {
             toolbarLeft.style.gap = '';
             if (this._lifelogToolbarLeftHTML) {
                 toolbarLeft.innerHTML = this._lifelogToolbarLeftHTML;
+                // innerHTML 替换后工具栏按钮事件监听丢失，重新绑定
+                const input = this.container.querySelector('#shuoshuo-input');
+                if (input) this._bindInputToolbar(input);
             }
         }
         const sendBtn = this.container.querySelector('.north-shuoshuo-send-btn');

--- a/index.js
+++ b/index.js
@@ -1962,6 +1962,12 @@ module.exports = class ShuoshuoPlugin extends Plugin {
         window.goBack = () => {
             const noNativeDialogs = !window.siyuan.dialogs || window.siyuan.dialogs.length === 0;
             if (noNativeDialogs) {
+                // 0. 图片/视频预览（z-index 最高，挂在 document.body 下）
+                const imagePreview = document.querySelector('.north-shuoshuo-image-preview-modal');
+                if (imagePreview) {
+                    imagePreview.remove();
+                    return;
+                }
                 // 1. 封面弹窗（网络图片链接 / 资源库选择）
                 const coverModal = this.container?.querySelector?.(
                     '.lumina-moments-cover-modal.active'

--- a/index.js
+++ b/index.js
@@ -1641,6 +1641,7 @@ module.exports = class ShuoshuoPlugin extends Plugin {
     }
 
     onunload() {
+        this.unhookMobileGoBack();
         if (this._luminaMobileTopBarTimer) {
             clearTimeout(this._luminaMobileTopBarTimer);
             this._luminaMobileTopBarTimer = null;
@@ -1901,7 +1902,6 @@ module.exports = class ShuoshuoPlugin extends Plugin {
 
     closeMobileShuoshuoDock() {
         try {
-            this.unhookMobileGoBack();
             // 清理热力图/日历残留的全局 tooltip
             const staleTooltip = document.querySelector('.north-shuoshuo-global-tooltip');
             if (staleTooltip) staleTooltip.remove();
@@ -3319,6 +3319,9 @@ ipcRenderer.on('lumina-close', () => {
         if (container) {
             this.container = container;
             this.registerLuminaContainer(container);
+        }
+        if (this.isMobile) {
+            this.hookMobileGoBack();
         }
         if (!this.container) return;
 

--- a/index.js
+++ b/index.js
@@ -1931,6 +1931,28 @@ module.exports = class ShuoshuoPlugin extends Plugin {
         return !!(this.container instanceof Element && this.container.closest?.('.north-shuoshuo-mobile-shell'));
     }
 
+    _suppressKeyboardToolbarOn(el) {
+        if (!el || !this.isMobile) return;
+        el.addEventListener('focus', () => {
+            if (this.isInMobileShell()) return;
+            const kb = document.getElementById('keyboardToolbar');
+            if (!kb) return;
+            this._kbObserver?.disconnect();
+            this._kbObserver = new MutationObserver(() => {
+                if (!kb.classList.contains('fn__none')) {
+                    kb.classList.add('fn__none');
+                    kb.style.height = '';
+                }
+            });
+            kb.classList.add('fn__none');
+            this._kbObserver.observe(kb, { attributes: true, attributeFilter: ['class'] });
+        });
+        el.addEventListener('blur', () => {
+            this._kbObserver?.disconnect();
+            this._kbObserver = null;
+        });
+    }
+
     hookMobileGoBack() {
         if (this._luminaGoBackHooked) return;
         const original = window.goBack;
@@ -9453,6 +9475,7 @@ ipcRenderer.on('lumina-close', () => {
         }
         // 朋友圈发表支持 Ctrl+V 粘贴图片/视频
         if (publishText) {
+            this._suppressKeyboardToolbarOn(publishText);
             publishText.addEventListener('paste', (e) => {
                 const items = e.clipboardData?.items;
                 if (!items) return;
@@ -13294,6 +13317,7 @@ ipcRenderer.on('lumina-close', () => {
                 this.handlePasteImage(e, input);
             });
         }
+        this._suppressKeyboardToolbarOn(input);
 
         // 输入监听，控制发送按钮，并自动转换列表符?
         if (input && sendBtn) {
@@ -13691,6 +13715,7 @@ ipcRenderer.on('lumina-close', () => {
                 }
             });
         }
+        this._suppressKeyboardToolbarOn(mobileSearchInput);
         const _mobileSearchRender = () => {
             if (this.currentMainView === 'lifelog') {
                 this.renderLifeLog();
@@ -14277,6 +14302,7 @@ ipcRenderer.on('lumina-close', () => {
                 debouncedSearch();
             });
         }
+        this._suppressKeyboardToolbarOn(searchInput);
 
         if (searchClear) {
             searchClear.addEventListener('click', () => {
@@ -19261,6 +19287,7 @@ ipcRenderer.on('lumina-close', () => {
         }
 
         const textarea = editBox.querySelector('.north-shuoshuo-inline-edit-field');
+        this._suppressKeyboardToolbarOn(textarea);
         const autoResize = () => {
             textarea.style.height = 'auto';
             textarea.style.height = Math.max(80, textarea.scrollHeight) + 'px';


### PR DESCRIPTION
## 修复内容

### 1. Dock 模式下输入框获焦时思源键盘栏遮挡

**现象**：
发表说说时快捷按钮的bug
- 通过插件方式进入轻语，发表新的说说，输入内容时，快捷按钮（插入序号，@键等等，插入图片）总是被隐藏。
<img width="492" height="1070" alt="image" src="https://github.com/user-attachments/assets/ceabe3b4-2e3e-4ae9-8a2e-d66a92cb98a5" />

- 通过熊猫导航进入轻语时，发表说说，输入内容时，快捷按钮正常。

<img width="496" height="1050" alt="image" src="https://github.com/user-attachments/assets/2b2c6fbe-d1a3-4a33-b6e4-0088d0fcab59" />


**原因分析**
插件 Dock 模式下轻语容器在 `#sidebar` 内部，textarea 获焦后思源 `#keyboardToolbar` 以递增高 z-index 浮在上面，48px 固定高度遮住轻语自己的快捷按钮栏。

**修改方案**
新增 `_suppressKeyboardToolbarOn()`，仅在 Dock 模式（非 Mobile Shell）下用 `MutationObserver` 持续隐藏 `#keyboardToolbar`，blur 后恢复。覆盖主输入框、内联编辑、朋友圈发表页、说说搜索框、移动端搜索框共 5 处输入框。

### 2. 进出 LifeLog 后说说工具栏按钮失灵

**现象**：
发表说说时快捷按钮bug（2）
一旦进入过lifelog页面，快捷按钮就直接失灵，导致发表新说说时，无法上传图片，无法插入序号等等
测试应该只影响到了这个输入框的快捷按钮，像编辑发布过的说说的输入框按钮是正常的

**原因分析**
进入 LifeLog 时工具栏 HTML 被缓存，切回说说时通过 `innerHTML` 恢复，导致按钮的点击事件全部丢失（经典的 innerHTML 替换问题）。

**修改方案**
将工具栏绑定逻辑提取为 `_bindInputToolbar(input)`，在 `innerHTML` 恢复后重新调用。仅在真正发生替换时（`_lifelogToolbarLeftHTML` 存在）才重新绑定，避免重复绑定导致点击两次。

### 3. 侧滑返回时优先关闭图片/视频预览

**现象**
上次新增的返回逻辑，当时忘记测试打开图片类型的了，打开图片后，用系统的返回，未关闭图片

**原因分析**
说说图片、朋友圈图片、视频预览共用 `.north-shuoshuo-image-preview-modal` 挂在 `document.body` 上（z-index:999999），但 goBack hook 拦截链中没有这一层。

**修改方案**
在拦截链最前面加一层 `document` 查询，命中则直接 `remove()`。

### 4. goBack hook 覆盖插件 Dock 入口

**现象**
上次新增的返回逻辑，只是能从熊猫导航进入的轻语能够用系统返回来关闭内容，但从插件进入的轻语，返回时会直接关闭侧边栏，不能正确先关闭内容

**原因分析**
`hookMobileGoBack()` 原先只在 `openMobileShuoshuoDock()`（熊猫导航入口）中调用，插件 Dock 入口走 `render()` 绕过它，导致 Dock 模式下侧滑返回完全无效。

**修改方案**
- 在 `render()` 中安装 hook（有 `_luminaGoBackHooked` 防重复）
- 将 `unhookMobileGoBack()` 从 `closeMobileShuoshuoDock()` 移到 `onunload()`，避免 Dock 进入后开关 mobile-shell 导致 hook 被提前移除

---

已在移动端完整测试，桌面端回归确认无影响。